### PR TITLE
Update deps, and version number to 0.4.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
-(defproject tinsel "0.4.0"
+(defproject tinsel "0.4.1"
   :description "Selector-based templates with Hiccup."
-  :dependencies [[org.clojure/clojure "1.3.0"]
-                 [hiccup "1.0.0"]
-                 [hickory "0.1.0"]])
+  :dependencies [[org.clojure/clojure "1.4.0"]
+                 [hiccup "1.0.3"]
+                 [hickory "0.4.1"]])

--- a/src/tinsel/core.clj
+++ b/src/tinsel/core.clj
@@ -270,7 +270,7 @@
   (let [html-string (if (string? string-or-reader)
                       string-or-reader
                       (slurp string-or-reader))]
-    (hickory/parse html-string)))
+    (hickory/as-hiccup (hickory/parse html-string))))
 
 (defn html-fragment
   "Parse an HTML fragment out of the argument given, which can be either a
@@ -279,7 +279,7 @@
   (let [html-string (if (string? string-or-reader)
                       string-or-reader
                       (slurp string-or-reader))]
-    (hickory/parse-fragment html-string)))
+    (map hickory/as-hiccup (hickory/parse-fragment html-string))))
 
 (defn hiccup-file
   "Parse hiccup forms out of the argument."


### PR DESCRIPTION
Update deps: hickory & hiccup to latest stable versions, clojure 1.4.0 to support ex-info (used in hickory). Also updated tinsel version to 0.4.1
